### PR TITLE
정리 : LDA 생성, BOW와 LDA를 함수로 따로 뗌, CV 스코어 추가

### DIFF
--- a/1.Feature Extraction - Author, Forum.ipynb
+++ b/1.Feature Extraction - Author, Forum.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -646,7 +646,7 @@
        "[172044 rows x 4 columns]"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -654,6 +654,7 @@
    "source": [
     "from konlpy.tag import Mecab\n",
     "\n",
+    "mecab = Mecab()\n",
     "mecab = Mecab()\n",
     "\n",
     "labeled_train = []\n",


### PR DESCRIPTION
forumid와 author, title, text의 pos를 bag of words로 변환 (feature : 1,000개) - 0.728390543803
forumid와 author, title, text의 pos를 LDA로 변환 (keep_n : 5,000, num_topics: 1,000) - 0.662467774802

LDA를 잘못 쓴건지 점수가 꽤 크게 차이나네요.

일단 1000개의 토픽에 관한 확률을 일일히 추가하지 말고 가장 높은 확률의 토픽 하나만 넣는 것도 일단 생각중입니다. (구현은 안함)